### PR TITLE
week 2 work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+*.bin
+*.vec

--- a/utilities/query.py
+++ b/utilities/query.py
@@ -49,7 +49,11 @@ def create_prior_queries(doc_ids, doc_id_weights,
 
 
 # Hardcoded query here.  Better to use search templates or other query config.
-def create_query(user_query, click_prior_query, filters, sort="_score", sortDir="desc", size=10, source=None):
+def create_query(user_query, click_prior_query, filters, sort="_score", sortDir="desc", size=10, source=None, synonyms=False):
+    if synonyms:
+        name_field = "name.synonyms"
+    else:
+        name_field = "name"
     query_obj = {
         'size': size,
         "sort": [
@@ -65,7 +69,7 @@ def create_query(user_query, click_prior_query, filters, sort="_score", sortDir=
                         "should": [  #
                             {
                                 "match": {
-                                    "name": {
+                                    name_field: {
                                         "query": user_query,
                                         "fuzziness": "1",
                                         "prefix_length": 2,
@@ -89,7 +93,7 @@ def create_query(user_query, click_prior_query, filters, sort="_score", sortDir=
                                     "type": "phrase",
                                     "slop": "6",
                                     "minimum_should_match": "2<75%",
-                                    "fields": ["name^10", "name.hyphens^10", "shortDescription^5",
+                                    "fields": [f"{name_field}^10", "name.hyphens^10", "shortDescription^5",
                                                "longDescription^5", "department^0.5", "sku", "manufacturer", "features",
                                                "categoryPath"]
                                 }
@@ -186,11 +190,19 @@ def create_query(user_query, click_prior_query, filters, sort="_score", sortDir=
     return query_obj
 
 
-def search(client, user_query, index="bbuy_products", sort="_score", sortDir="desc"):
+def search(client, user_query, index="bbuy_products", sort="_score", sortDir="desc", synonyms=False, size=10):
     #### W3: classify the query
     #### W3: create filters and boosts
     # Note: you may also want to modify the `create_query` method above
-    query_obj = create_query(user_query, click_prior_query=None, filters=None, sort=sort, sortDir=sortDir, source=["name", "shortDescription"])
+    query_obj = create_query(
+        user_query,
+        click_prior_query=None,
+        filters=None, sort=sort,
+        sortDir=sortDir,
+        size=size,
+        source=["name", "shortDescription"],
+        synonyms=synonyms
+    )
     logging.info(query_obj)
     response = client.search(query_obj, index=index)
     if response and response['hits']['hits'] and len(response['hits']['hits']) > 0:
@@ -204,12 +216,15 @@ if __name__ == "__main__":
     auth = ('admin', 'admin')  # For testing only. Don't store credentials in code.
     parser = argparse.ArgumentParser(description='Build LTR.')
     general = parser.add_argument_group("general")
+    general.add_argument("query")
     general.add_argument("-i", '--index', default="bbuy_products",
                          help='The name of the main index to search')
     general.add_argument("-s", '--host', default="localhost",
                          help='The OpenSearch host name')
     general.add_argument("-p", '--port', type=int, default=9200,
                          help='The OpenSearch port')
+    general.add_argument("--synonyms", action="store_true")
+    general.add_argument("--size", "-n", type=int, default=10)
     general.add_argument('--user',
                          help='The OpenSearch admin.  If this is set, the program will prompt for password too. If not set, use default of admin/admin')
 
@@ -238,15 +253,5 @@ if __name__ == "__main__":
         ssl_show_warn=False,
 
     )
-    index_name = args.index
-    query_prompt = "\nEnter your query (type 'Exit' to exit or hit ctrl-c):"
-    print(query_prompt)
-    for line in fileinput.input():
-        query = line.rstrip()
-        if query == "Exit":
-            break
-        search(client=opensearch, user_query=query, index=index_name)
 
-        print(query_prompt)
-
-    
+    search(client=opensearch, user_query=args.query, index=args.index, synonyms=args.synonyms, size=args.size)

--- a/week2/assessment.md
+++ b/week2/assessment.md
@@ -1,4 +1,4 @@
-### Project Assessment
+# Project Assessment
 ## For classifying product names to categories:
 * What precision (P@1) were you able to achieve?
     ```

--- a/week2/assessment.md
+++ b/week2/assessment.md
@@ -1,0 +1,79 @@
+### Project Assessment
+## For classifying product names to categories:
+* What precision (P@1) were you able to achieve?
+    ```
+    N	8473
+    P@1	0.963
+    R@1	0.963
+    ```
+* What fastText parameters did you use?
+    ```
+    EPOCHS=25
+    NGRAMS=1
+    LEARNING_RATE=1.0
+    ```
+* How did you transform the product names?
+    * Remove all non-alphanumeric characters other than underscore.
+    * Convert all letters to lowercase.
+    * Trim excess space characters so that tokens are separated by a single space.
+
+* How did you prune infrequent category labels, and how did that affect your precision?
+    * Caclulated the total count of all leaf-level labels.
+    * Calculated the total count of all depth=2-level labels.
+    * I kept labels leaf-level labels OR depth=2-level labels:
+        * leaf-level label count > 500
+        * depth=2-level label count was > 500 -- if this was met then the label
+          for the corresponding leaf-level label was rolled up to its depth=2-level parent label
+
+    Precision increased substantiall from ~0.21 to ~0.96.
+* How did you prune the category tree, and how did that affect your precision?
+    * See response above.
+
+## For deriving synonyms from content:
+* What were the results for your best model in the tokens used for evaluation?
+    ```
+    # headphones
+    earbud 0.871863
+    ear 0.804368
+    bud 0.739856
+    noise 0.729004
+
+    # nintendo
+    wii 0.770601
+    ds 0.760249
+    game 0.645096
+    playstation 0.642175
+    ps2 0.64045
+
+    # ps2
+    psp 0.83028
+    ps3 0.823938
+    gba 0.772662
+    gamecube 0.727795
+    xbox 0.698361
+
+    # plasma
+    58 0.771785
+    600hz 0.738228
+    42 0.694399
+    63 0.693472
+    hdtv 0.677367
+    ```
+* What fastText parameters did you use?
+    ```
+    EPOCHS=25
+    MODEL_TYPE="skipgram"
+    MIN_COUNT=20
+    ```
+* How did you transform the product names?
+    ```
+    cat /workspace/datasets/fasttext/titles.txt | sed -e "s/\([.\!?,'/()]\)/ \1 /g" | tr "[:upper:]" "[:lower:]" | sed "s/[^[:alnum:]]/ /g" | tr -s ' ' > /workspace/datasets/fasttext/normalized_titles.txt
+    ```
+
+## For integrating synonyms with search:
+* How did you transform the product names (if different than previously)?
+I used the same as above.
+* What threshold score did you use?
+0.8 because I favored precision over recall. Probably should have gone even higher :)
+* Were you able to find the additional results by matching synonyms?
+Yes, I was able to see the result set increase in number when using the `--synonyms` flag that I added to `query.py`

--- a/week2/clean_labeled_products_data.py
+++ b/week2/clean_labeled_products_data.py
@@ -1,0 +1,73 @@
+from argparse import ArgumentParser
+from collections import Counter
+import xml.etree.ElementTree as ET
+
+CATEGORIES_FN = r'/workspace/datasets/product_data/categories/categories_0001_abcat0010000_to_pcmcat99300050000.xml'
+
+
+def generate_leaf_to_parent_categories(category_tree, parent_level=2, label_str="__label__"):
+    leaf_to_parent_categories = dict()
+    parent_counts = Counter()
+    for child in tree.getroot():
+        cat_path = child.find("path")
+        cat_path_ids = [cat.find("id").text for cat in cat_path]
+        if len(cat_path_ids) > parent_level:
+            parent = label_str + cat_path_ids[parent_level]
+            leaf = label_str + cat_path_ids[-1]
+            if parent != leaf:
+                leaf_to_parent_categories[leaf] = parent
+                parent_counts[parent] += 1
+    return leaf_to_parent_categories, parent_counts
+
+
+def get_class_counts(data):
+    class_counts = Counter()
+    for (label, *_) in data:
+        class_counts[label] += 1
+    return class_counts
+
+
+def filter_data_by_class_count(
+        data,
+        class_counts,
+        leaf_to_parent_categories,
+        min_class_count=500,
+    ):
+    new_data = []
+    for (label, *text) in data:
+        class_count = class_counts[label]
+        if class_count > min_class_count:
+            new_data.append((label, text))
+        elif label in leaf_to_parent_categories and class_counts[leaf_to_parent_categories[label]] > min_class_count:
+            parent_category_label = leaf_to_parent_categories[label]
+            new_data.append((parent_category_label, text))
+    return new_data
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument("labeled_products_fn")
+    parser.add_argument("labeled_products_clean_fn")
+    parser.add_argument("--min_class_count", "-m", type=int, default=500)
+    args = parser.parse_args()
+
+    tree = ET.parse(CATEGORIES_FN)
+    leaf_to_parent_categories, parent_counts = generate_leaf_to_parent_categories(tree)
+    with open(args.labeled_products_fn) as f:
+        # each line formatted as space delimited list of strings with first being the label
+        # E.g. "__label__abcat0515028 HP - Mini Laptop Sleeve"
+        data = [x.split() for x in f]
+
+    class_counts = get_class_counts(data)
+    class_counts.update(parent_counts)
+    data_pruned = filter_data_by_class_count(
+        data,
+        class_counts,
+        leaf_to_parent_categories,
+        min_class_count=args.min_class_count
+    )
+
+    with open(args.labeled_products_clean_fn, 'w') as f:
+        for (label, text) in data_pruned:
+            line = " ".join([label, " ".join(text)+"\n"])
+            f.write(line)

--- a/week2/conf/bbuy_products.json
+++ b/week2/conf/bbuy_products.json
@@ -8,6 +8,14 @@
             "smarter_hyphens_filter",
             "lowercase"
           ]
+        },
+        "synonyms_analyzer": {
+          "tokenizer": "whitespace",
+          "filter": [
+            "stemmer",
+            "lowercase",
+            "synonyms_filter"
+          ]
         }
       },
       "tokenizer": {
@@ -24,6 +32,10 @@
           "type": "word_delimiter_graph",
           "catenate_words": true,
           "catenate_all": true
+        },
+        "synonyms_filter": {
+          "type": "synonym",
+          "synonyms_path": "synonyms.csv"
         }
       }
     }
@@ -248,8 +260,11 @@
           },
           "suggest": {
             "type": "completion"
+          },
+          "synonyms": {
+            "type": "text",
+            "analyzer": "synonyms_analyzer"
           }
-
         }
       },
       "onSale": {

--- a/week2/generate_synonyms.py
+++ b/week2/generate_synonyms.py
@@ -1,0 +1,40 @@
+from argparse import ArgumentParser
+import fasttext
+
+
+class SynonymGenerator:
+    def __init__(self, model_fn):
+        self.model = fasttext.load_model(model_fn)
+
+    def _synonymize(self, keyword, threshold=0.75):
+        synonyms = self.model.get_nearest_neighbors(keyword, k=20)
+        for (score, synonym) in synonyms:
+            if score > threshold:
+                yield synonym
+
+    def generate_synonyms_list(self, keywords, threshold=0.75):
+        synonyms = dict()
+        for keyword in keywords:
+            valid_synonyms = list(self._synonymize(keyword))
+            if valid_synonyms:
+                synonyms[keyword] = valid_synonyms
+        return synonyms
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument("keywords_fn")
+    parser.add_argument("model_fn")
+    parser.add_argument("--synonyms_fn", "-o", default="/workspace/datasets/fasttext/synonyms.csv")
+    parser.add_argument("--threshold", "-t", type=float, default=0.75)
+    args = parser.parse_args()
+
+    with open(args.keywords_fn) as f:
+        keywords = f.read().splitlines()
+
+    synonym_generator = SynonymGenerator(args.model_fn)
+    synonyms = synonym_generator.generate_synonyms_list(keywords, threshold=args.threshold)
+
+    with open(args.synonyms_fn, "w") as f:
+        for keyword, synonyms in sorted(synonyms.items()):
+            line = ",".join([keyword, ",".join(synonyms)])
+            f.write(line+'\n')

--- a/week2/generate_train_test_data.sh
+++ b/week2/generate_train_test_data.sh
@@ -1,0 +1,30 @@
+#! /usr/bin/env bash
+labeled_products="${1:-/workspace/datasets/fasttext/labeled_products.txt}"
+normalize="${2:-N}"
+
+LABELED_PRODUCTS_SHUFFLED="/workspace/datasets/fasttext/shuffled_labeled_products.txt"
+TRAIN_DATA="/workspace/datasets/fasttext/training_data.txt"
+TEST_DATA="/workspace/datasets/fasttext/test_data.txt"
+
+printf "Shuffling ${labeled_products} file\\n"
+shuf ${labeled_products} --random-source=<(seq 99999) > ${LABELED_PRODUCTS_SHUFFLED}
+FIRST_LINE=$(head -1 ${LABELED_PRODUCTS_SHUFFLED})
+FIRST_LINE_VALID="__label__abcat0401002 Canon - PowerShot 10.0-Megapixel Digital Camera - Black"
+LAST_LINE=$(tail -1 ${LABELED_PRODUCTS_SHUFFLED})
+LAST_LINE_VALID="__label__abcat0401004 Canon A1100 IS Blue 12.1MP Digital Camera with Tripod, Bag and Memory Card"
+printf "\\tActual first line:${FIRST_LINE}\\n\\tValid first line: ${FIRST_LINE_VALID}\\n"
+printf "\\tActual last line:${LAST_LINE}\\n\\tValid last line: ${LAST_LINE_VALID}\\n"
+
+if [ ${normalize,,} = "y" ]
+then
+    LABELED_PRODUCTS_SHUFFLED_NORMALIZED="/workspace/datasets/fasttext/normalized_labeled_products.txt"
+    printf "Normalizing ${LABELED_PRODUCTS_SHUFFLED}\\n"
+    cat ${LABELED_PRODUCTS_SHUFFLED} |sed -e "s/\([.\!?,'/()]\)/ \1 /g" | tr "[:upper:]" "[:lower:]" | sed "s/[^[:alnum:]_]/ /g" | tr -s ' ' > ${LABELED_PRODUCTS_SHUFFLED_NORMALIZED}
+    printf "Creating train and test data files from normalized data\\n"
+    head -10000 ${LABELED_PRODUCTS_SHUFFLED_NORMALIZED} > ${TRAIN_DATA}
+    tail -10000 ${LABELED_PRODUCTS_SHUFFLED_NORMALIZED} > ${TEST_DATA}
+else
+    printf "Creating train and test data files from raw data\\n"
+    head -10000 ${LABELED_PRODUCTS_SHUFFLED} > ${TRAIN_DATA}
+    tail -10000 ${LABELED_PRODUCTS_SHUFFLED} > ${TEST_DATA}
+fi

--- a/week2/test_fasttext.sh
+++ b/week2/test_fasttext.sh
@@ -1,0 +1,6 @@
+#! /usr/bin/env bash
+set -x
+N=${1:-1}
+TEST_DATA="/workspace/datasets/fasttext/test_data.txt"
+MODEL_FILE="/workspace/search_with_machine_learning_course/week2/product_classifier.bin"
+fasttext test ${MODEL_FILE} ${TEST_DATA} ${N}

--- a/week2/train_fasttext.sh
+++ b/week2/train_fasttext.sh
@@ -1,0 +1,9 @@
+#! /usr/bin/env bash
+set -x
+TRAIN_DATA="${1:-/workspace/datasets/fasttext/training_data.txt}"
+MODEL_FILE="product_classifier"
+EPOCHS=25
+NGRAMS=1
+LEARNING_RATE=1.0
+MODEL_TYPE="skipgram"
+fasttext supervised -input ${TRAIN_DATA} -output ${MODEL_FILE} -lr ${LEARNING_RATE} -epoch ${EPOCHS} -wordNgrams ${NGRAMS}

--- a/week2/train_fasttext_titles.sh
+++ b/week2/train_fasttext_titles.sh
@@ -1,0 +1,8 @@
+#! /usr/bin/env bash
+set -x
+TRAIN_DATA="${1:-/workspace/datasets/fasttext/normalized_titles.txt}"
+MODEL_FILE="title_model"
+EPOCHS=25
+MODEL_TYPE="skipgram"
+MIN_COUNT=20
+fasttext skipgram -input ${TRAIN_DATA} -output ${MODEL_FILE} -epoch ${EPOCHS} -minCount ${MIN_COUNT}


### PR DESCRIPTION
# Project Assessment
## For classifying product names to categories:
* What precision (P@1) were you able to achieve?
    ```
    N	8473
    P@1	0.963
    R@1	0.963
    ```
* What fastText parameters did you use?
    ```
    EPOCHS=25
    NGRAMS=1
    LEARNING_RATE=1.0
    ```
* How did you transform the product names?
    * Remove all non-alphanumeric characters other than underscore.
    * Convert all letters to lowercase.
    * Trim excess space characters so that tokens are separated by a single space.

* How did you prune infrequent category labels, and how did that affect your precision?
    * Caclulated the total count of all leaf-level labels.
    * Calculated the total count of all depth=2-level labels.
    * I kept labels leaf-level labels OR depth=2-level labels:
        * leaf-level label count > 500
        * depth=2-level label count was > 500 -- if this was met then the label
          for the corresponding leaf-level label was rolled up to its depth=2-level parent label

    Precision increased substantiall from ~0.21 to ~0.96.
* How did you prune the category tree, and how did that affect your precision?
    * See response above.

## For deriving synonyms from content:
* What were the results for your best model in the tokens used for evaluation?
    ```
    # headphones
    earbud 0.871863
    ear 0.804368
    bud 0.739856
    noise 0.729004

    # nintendo
    wii 0.770601
    ds 0.760249
    game 0.645096
    playstation 0.642175
    ps2 0.64045

    # ps2
    psp 0.83028
    ps3 0.823938
    gba 0.772662
    gamecube 0.727795
    xbox 0.698361

    # plasma
    58 0.771785
    600hz 0.738228
    42 0.694399
    63 0.693472
    hdtv 0.677367
    ```
* What fastText parameters did you use?
    ```
    EPOCHS=25
    MODEL_TYPE="skipgram"
    MIN_COUNT=20
    ```
* How did you transform the product names?
    ```
    cat /workspace/datasets/fasttext/titles.txt | sed -e "s/\([.\!?,'/()]\)/ \1 /g" | tr "[:upper:]" "[:lower:]" | sed "s/[^[:alnum:]]/ /g" | tr -s ' ' > /workspace/datasets/fasttext/normalized_titles.txt
    ```

## For integrating synonyms with search:
* How did you transform the product names (if different than previously)?
I used the same as above.
* What threshold score did you use?
0.8 because I favored precision over recall. Probably should have gone even higher :)
* Were you able to find the additional results by matching synonyms?
Yes, I was able to see the result set increase in number when using the `--synonyms` flag that I added to `query.py`